### PR TITLE
Modernize codebase and add unit tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,19 +1,34 @@
-// swift-tools-version:5.4
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(
     name: "MaterialDesignSymbol",
-    platforms: [.iOS(.v10),
-                .watchOS(.v3)],
-    products: [
-        .library(name: "MaterialDesignSymbol", targets: ["MaterialDesignSymbol"])
+    platforms: [
+        .iOS(.v14),
+        .watchOS(.v7)
     ],
-    dependencies: [],
+    products: [
+        .library(
+            name: "MaterialDesignSymbol",
+            targets: ["MaterialDesignSymbol"]
+        )
+    ],
     targets: [
-        .target(name: "MaterialDesignSymbol",
-                resources: [
-                    .process("Resources")])
+        .target(
+            name: "MaterialDesignSymbol",
+            resources: [
+                .process("Resources")
+            ],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
+        ),
+        .testTarget(
+            name: "MaterialDesignSymbolTests",
+            dependencies: ["MaterialDesignSymbol"]
+        )
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Sources/MaterialDesignSymbol/FontLoader.swift
+++ b/Sources/MaterialDesignSymbol/FontLoader.swift
@@ -5,50 +5,76 @@
 //  Copyright (c) 2015 tichise. All rights reserved.
 //
 
-#if !os(macOS)
+#if canImport(UIKit)
 import UIKit
+import CoreText
 
-/**
- フォント読み込み用クラス
- */
-public class FontLoader {
-    
-    /**
-     引数で渡ってきたフォントを読み込みます
-     - parameter name: フォントファイル名
-     */
-    public class func loadFont(_ name: String) throws {
+/// Errors that can occur during font loading
+public enum FontError: Error, CustomStringConvertible, Sendable {
+    case fontFileNotFound(name: String)
+    case invalidFontData
+    case fontCreationFailed
+    case registrationFailed(Error?)
 
-        guard let ttfPath = Bundle(for: object_getClass(self)!).path(forResource: name, ofType: "ttf") else {
-            throw FontError.invalidFontFile
-        }
-
-        guard let fileHandle = FileHandle(forReadingAtPath: ttfPath) else {
-            throw FontError.fontPathNotFound
-        }
-
-        let data = fileHandle.readDataToEndOfFile()
-
-        guard let provider = CGDataProvider(data: data as CFData) else {
-            throw FontError.invalidFontFile
-        }
-
-        guard let font = CGFont(provider) else {
-            throw FontError.initFontError
-        }
-
-        var error: Unmanaged<CFError>?
-
-        if !CTFontManagerRegisterGraphicsFont(font, &error) {
-            throw FontError.registerFailed
+    public var description: String {
+        switch self {
+        case .fontFileNotFound(let name):
+            return "Font file '\(name).ttf' not found in bundle"
+        case .invalidFontData:
+            return "Invalid font data"
+        case .fontCreationFailed:
+            return "Failed to create font from data"
+        case .registrationFailed(let error):
+            if let error = error {
+                return "Font registration failed: \(error.localizedDescription)"
+            }
+            return "Font registration failed"
         }
     }
 }
 
-public enum FontError: Error {
-  case invalidFontFile
-  case fontPathNotFound
-  case initFontError
-  case registerFailed
+/// Utility class for loading custom fonts
+public enum FontLoader {
+
+    /// Load and register a font from the bundle
+    /// - Parameter name: The font file name (without extension)
+    /// - Throws: FontError if loading fails
+    public static func loadFont(_ name: String) throws {
+        guard let ttfPath = Bundle(for: BundleToken.self).path(forResource: name, ofType: "ttf") else {
+            throw FontError.fontFileNotFound(name: name)
+        }
+
+        let fontURL = URL(fileURLWithPath: ttfPath)
+
+        guard let fontData = try? Data(contentsOf: fontURL) else {
+            throw FontError.invalidFontData
+        }
+
+        guard let provider = CGDataProvider(data: fontData as CFData) else {
+            throw FontError.invalidFontData
+        }
+
+        guard let font = CGFont(provider) else {
+            throw FontError.fontCreationFailed
+        }
+
+        var error: Unmanaged<CFError>?
+        let success = CTFontManagerRegisterGraphicsFont(font, &error)
+
+        if !success {
+            let cfError = error?.takeRetainedValue()
+            // Check if it's already registered (not a real error)
+            if let cfError = cfError {
+                let nsError = cfError as Error
+                if (nsError as NSError).code == CTFontManagerError.alreadyRegistered.rawValue {
+                    return // Font already registered, not an error
+                }
+            }
+            throw FontError.registrationFailed(cfError.map { $0 as Error })
+        }
+    }
 }
+
+/// Helper class to get the correct bundle
+private final class BundleToken {}
 #endif

--- a/Sources/MaterialDesignSymbol/MaterialDesignIcon.swift
+++ b/Sources/MaterialDesignSymbol/MaterialDesignIcon.swift
@@ -5,13 +5,11 @@
 //  Copyright (c) 2015 tichise. All rights reserved.
 //
 
-#if !os(macOS)
+#if canImport(UIKit)
 import UIKit
 
-/**
- * マテリアルデザインアイコンのコードを返す構造体
- */
-@available(iOS, deprecated: 13.0)
-public struct MaterialDesignIcon {
-}
+/// Legacy struct for Material Design icon constants
+/// - Note: Use `MaterialDesignIconEnum` instead for modern Swift code
+@available(iOS, deprecated: 14.0, message: "Use MaterialDesignIconEnum instead")
+public struct MaterialDesignIcon: Sendable {}
 #endif

--- a/Sources/MaterialDesignSymbol/MaterialDesignIcon1.swift
+++ b/Sources/MaterialDesignSymbol/MaterialDesignIcon1.swift
@@ -5,12 +5,11 @@
 //  Copyright (c) 2015 tichise. All rights reserved.
 //
 
-#if !os(macOS)
+#if canImport(UIKit)
 import UIKit
 
-/**
- * マテリアルデザインアイコンのコードを返すクラス
- */
+/// Legacy Material Design icon constants (Part 1)
+/// - Note: Use `MaterialDesignIconEnum` instead for modern Swift code
 extension MaterialDesignIcon {
     public static let threeDRotation24px = "\u{e600}"
     public static let threeDRotation48px = "\u{e601}"

--- a/Sources/MaterialDesignSymbol/MaterialDesignIcon2.swift
+++ b/Sources/MaterialDesignSymbol/MaterialDesignIcon2.swift
@@ -5,12 +5,11 @@
 //  Copyright (c) 2015 tichise. All rights reserved.
 //
 
-#if !os(macOS)
+#if canImport(UIKit)
 import UIKit
 
-/**
- * マテリアルデザインアイコンのコードを返すクラス
- */
+/// Legacy Material Design icon constants (Part 2)
+/// - Note: Use `MaterialDesignIconEnum` instead for modern Swift code
 extension MaterialDesignIcon {
     public static let repeatOne24px = "\u{e78f}"
     public static let repeatOne48px = "\u{e790}"

--- a/Sources/MaterialDesignSymbol/MaterialDesignIcon3.swift
+++ b/Sources/MaterialDesignSymbol/MaterialDesignIcon3.swift
@@ -5,12 +5,11 @@
 //  Copyright (c) 2015 tichise. All rights reserved.
 //
 
-#if !os(macOS)
+#if canImport(UIKit)
 import UIKit
 
-/**
- * マテリアルデザインアイコンのコードを返すクラス
- */
+/// Legacy Material Design icon constants (Part 3)
+/// - Note: Use `MaterialDesignIconEnum` instead for modern Swift code
 extension MaterialDesignIcon {
     public static let borderColor18px = "\u{e91e}"
     public static let borderColor24px = "\u{e91f}"

--- a/Sources/MaterialDesignSymbol/MaterialDesignIcon4.swift
+++ b/Sources/MaterialDesignSymbol/MaterialDesignIcon4.swift
@@ -5,12 +5,11 @@
 //  Copyright (c) 2015 tichise. All rights reserved.
 //
 
-#if !os(macOS)
+#if canImport(UIKit)
 import UIKit
 
-/**
- * マテリアルデザインアイコンのコードを返すクラス
- */
+/// Legacy Material Design icon constants (Part 4)
+/// - Note: Use `MaterialDesignIconEnum` instead for modern Swift code
 extension MaterialDesignIcon {
     public static let flip48px = "\u{eaad}"
     public static let gradient24px = "\u{eaae}"

--- a/Sources/MaterialDesignSymbol/MaterialDesignIcon5.swift
+++ b/Sources/MaterialDesignSymbol/MaterialDesignIcon5.swift
@@ -5,12 +5,11 @@
 //  Copyright (c) 2015 tichise. All rights reserved.
 //
 
-#if !os(macOS)
+#if canImport(UIKit)
 import UIKit
 
-/**
- * マテリアルデザインアイコンのコードを返すクラス
- */
+/// Legacy Material Design icon constants (Part 5)
+/// - Note: Use `MaterialDesignIconEnum` instead for modern Swift code
 extension MaterialDesignIcon {
     public static let voiceChat24px = "\u{ec3c}"
     public static let voiceChat48px = "\u{ec3d}"

--- a/Sources/MaterialDesignSymbol/MaterialDesignIconEnum.swift
+++ b/Sources/MaterialDesignSymbol/MaterialDesignIconEnum.swift
@@ -2,13 +2,11 @@
 //  MaterialDesignIconEnum
 //
 
-#if !os(macOS)
+#if canImport(UIKit)
 import UIKit
 
-/**
- * マテリアルデザインアイコンのコードを返すenum
- */
-public enum MaterialDesignIconEnum: String {
+/// Material Design icon enum with Unicode character mappings
+public enum MaterialDesignIconEnum: String, Sendable, CaseIterable {
     case threeDRotation24px = "\u{e600}"
     case threeDRotation48px = "\u{e601}"
     case accessibility24px = "\u{e602}"

--- a/Sources/MaterialDesignSymbol/MaterialDesignSymbol.swift
+++ b/Sources/MaterialDesignSymbol/MaterialDesignSymbol.swift
@@ -5,90 +5,82 @@
 //  Copyright (c) 2015 tichise. All rights reserved.
 //
 
-#if !os(macOS)
+#if canImport(UIKit)
 import UIKit
 
-/**
- * MaterialDesignSymbolのメインクラス
- */
-public class MaterialDesignSymbol {
+/// Main class for rendering Material Design icons as images
+@MainActor
+public final class MaterialDesignSymbol: Sendable {
 
-    var text = ""
-    var fontOfSize: CGFloat = 30
+    private let text: String
+    private let fontSize: CGFloat
+    private var attributes: [NSAttributedString.Key: Any]
 
-    var mutableTextFontAttributes = [NSAttributedString.Key: Any]()
-    
+    /// Initialize with a Material Design icon enum value
+    /// - Parameters:
+    ///   - icon: The icon to display
+    ///   - size: The font size for the icon
     public init(icon: MaterialDesignIconEnum, size: CGFloat) {
         self.text = icon.rawValue
-        self.fontOfSize = size
-
-        self.mutableTextFontAttributes = [NSAttributedString.Key: Any]()
-        
-        if let paragraphStyle = NSMutableParagraphStyle.default.mutableCopy() as? NSMutableParagraphStyle {
-            self.mutableTextFontAttributes[NSAttributedString.Key.paragraphStyle] = paragraphStyle
-        }
-
-        self.mutableTextFontAttributes[NSAttributedString.Key.font] = MaterialDesignFont.shared.fontOfSize(size)
+        self.fontSize = size
+        self.attributes = Self.createDefaultAttributes(size: size)
     }
 
+    /// Initialize with a raw text string (Unicode character)
+    /// - Parameters:
+    ///   - text: The Unicode character for the icon
+    ///   - size: The font size for the icon
     public init(text: String, size: CGFloat) {
         self.text = text
-        self.fontOfSize = size
+        self.fontSize = size
+        self.attributes = Self.createDefaultAttributes(size: size)
+    }
 
-        self.mutableTextFontAttributes = [NSAttributedString.Key: Any]()
-        
+    private static func createDefaultAttributes(size: CGFloat) -> [NSAttributedString.Key: Any] {
+        var attrs: [NSAttributedString.Key: Any] = [:]
+
         if let paragraphStyle = NSMutableParagraphStyle.default.mutableCopy() as? NSMutableParagraphStyle {
-            self.mutableTextFontAttributes[NSAttributedString.Key.paragraphStyle] = paragraphStyle
+            attrs[.paragraphStyle] = paragraphStyle
         }
 
-        self.mutableTextFontAttributes[NSAttributedString.Key.font] = MaterialDesignFont.shared.fontOfSize(size)
+        attrs[.font] = MaterialDesignFont.shared.fontOfSize(size)
+        return attrs
     }
 
-    // MARK: - Method
+    // MARK: - Attribute Methods
+
+    /// Add a custom attribute to the icon
+    /// - Parameters:
+    ///   - attributeName: The attribute key
+    ///   - value: The attribute value
     public func addAttribute(attributeName: NSAttributedString.Key, value: Any) {
-        self.mutableTextFontAttributes[attributeName] = value
+        attributes[attributeName] = value
     }
-    
+
+    /// Set the foreground color of the icon
+    /// - Parameter foregroundColor: The color to apply
     public func addAttribute(foregroundColor: UIColor) {
-        addAttribute(attributeName: NSAttributedString.Key.foregroundColor, value: foregroundColor)
+        addAttribute(attributeName: .foregroundColor, value: foregroundColor)
     }
 
-    /**
-     // アイコンを画像形式で取得するのに使うメソッド
-     - parameter size: サイズ
-     - returns: UIImage
-     */
+    // MARK: - Image Generation
+
+    /// Generate an image from the icon with the specified size
+    /// - Parameter size: The size of the output image
+    /// - Returns: The rendered UIImage
     public func image(size: CGSize) -> UIImage {
-        UIGraphicsBeginImageContextWithOptions(size, false, 0)
-
-        let textRect  = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-        self.text.draw(in: textRect, withAttributes: self.mutableTextFontAttributes)
-
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-
-        UIGraphicsEndImageContext()
-
-        return image!
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { _ in
+            let textRect = CGRect(origin: .zero, size: size)
+            text.draw(in: textRect, withAttributes: attributes)
+        }
     }
-    
-    /**
-     // アイコンを画像形式で取得するのに使うメソッド
-     - parameter size: サイズ
-     - returns: UIImage
-     */
+
+    /// Generate a square image from the icon using the font size as dimensions
+    /// - Returns: The rendered UIImage
     public func image() -> UIImage {
-        let size = CGSize(width: fontOfSize, height: fontOfSize)
-        
-        UIGraphicsBeginImageContextWithOptions(size, false, 0)
-
-        let textRect  = CGRect(x: 0, y: 0, width: size.width, height: size.height)
-        self.text.draw(in: textRect, withAttributes: self.mutableTextFontAttributes)
-
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-
-        UIGraphicsEndImageContext()
-
-        return image!
+        let size = CGSize(width: fontSize, height: fontSize)
+        return image(size: size)
     }
 }
 #endif

--- a/Tests/MaterialDesignSymbolTests/MaterialDesignSymbolTests.swift
+++ b/Tests/MaterialDesignSymbolTests/MaterialDesignSymbolTests.swift
@@ -1,0 +1,175 @@
+//
+//  MaterialDesignSymbolTests
+//
+//  Created by Claude on 2024.
+//
+
+#if canImport(UIKit)
+import XCTest
+@testable import MaterialDesignSymbol
+
+@MainActor
+final class MaterialDesignSymbolTests: XCTestCase {
+
+    // MARK: - MaterialDesignSymbol Tests
+
+    func testInitWithIcon() {
+        let symbol = MaterialDesignSymbol(icon: .home48px, size: 24)
+        let image = symbol.image()
+
+        XCTAssertEqual(image.size.width, 24)
+        XCTAssertEqual(image.size.height, 24)
+    }
+
+    func testInitWithText() {
+        let icon = MaterialDesignIconEnum.settings48px
+        let symbol = MaterialDesignSymbol(text: icon.rawValue, size: 32)
+        let image = symbol.image()
+
+        XCTAssertEqual(image.size.width, 32)
+        XCTAssertEqual(image.size.height, 32)
+    }
+
+    func testImageWithCustomSize() {
+        let symbol = MaterialDesignSymbol(icon: .search48px, size: 24)
+        let customSize = CGSize(width: 48, height: 48)
+        let image = symbol.image(size: customSize)
+
+        XCTAssertEqual(image.size.width, 48)
+        XCTAssertEqual(image.size.height, 48)
+    }
+
+    func testImageWithNonSquareSize() {
+        let symbol = MaterialDesignSymbol(icon: .menu48px, size: 24)
+        let customSize = CGSize(width: 60, height: 40)
+        let image = symbol.image(size: customSize)
+
+        XCTAssertEqual(image.size.width, 60)
+        XCTAssertEqual(image.size.height, 40)
+    }
+
+    func testAddForegroundColor() {
+        let symbol = MaterialDesignSymbol(icon: .favorite48px, size: 24)
+        symbol.addAttribute(foregroundColor: .red)
+        let image = symbol.image()
+
+        XCTAssertNotNil(image)
+        XCTAssertEqual(image.size.width, 24)
+    }
+
+    func testAddCustomAttribute() {
+        let symbol = MaterialDesignSymbol(icon: .stars48px, size: 24)
+        symbol.addAttribute(attributeName: .foregroundColor, value: UIColor.blue)
+        symbol.addAttribute(attributeName: .backgroundColor, value: UIColor.white)
+        let image = symbol.image()
+
+        XCTAssertNotNil(image)
+    }
+
+    func testMultipleSizes() {
+        let sizes: [CGFloat] = [12, 18, 24, 36, 48, 72, 96]
+
+        for size in sizes {
+            let symbol = MaterialDesignSymbol(icon: .add48px, size: size)
+            let image = symbol.image()
+
+            XCTAssertEqual(image.size.width, size, "Width should match for size \(size)")
+            XCTAssertEqual(image.size.height, size, "Height should match for size \(size)")
+        }
+    }
+
+    // MARK: - MaterialDesignFont Tests
+
+    func testFontCreation() {
+        let font = MaterialDesignFont.shared.fontOfSize(24)
+
+        XCTAssertNotNil(font)
+        XCTAssertEqual(font.pointSize, 24)
+    }
+
+    func testStaticFontCreation() {
+        let font = MaterialDesignFont.fontOfSize(32)
+
+        XCTAssertNotNil(font)
+        XCTAssertEqual(font.pointSize, 32)
+    }
+
+    func testFontCreationMultipleSizes() {
+        let sizes: [CGFloat] = [10, 14, 18, 24, 36, 48]
+
+        for size in sizes {
+            let font = MaterialDesignFont.shared.fontOfSize(size)
+            XCTAssertEqual(font.pointSize, size, "Font size should be \(size)")
+        }
+    }
+
+    // MARK: - MaterialDesignIconEnum Tests
+
+    func testIconEnumRawValue() {
+        let icon = MaterialDesignIconEnum.home48px
+
+        XCTAssertFalse(icon.rawValue.isEmpty)
+        XCTAssertEqual(icon.rawValue.count, 1) // Should be a single Unicode character
+    }
+
+    func testDifferentIconsHaveDifferentRawValues() {
+        let icon1 = MaterialDesignIconEnum.home48px
+        let icon2 = MaterialDesignIconEnum.settings48px
+        let icon3 = MaterialDesignIconEnum.search48px
+
+        XCTAssertNotEqual(icon1.rawValue, icon2.rawValue)
+        XCTAssertNotEqual(icon2.rawValue, icon3.rawValue)
+        XCTAssertNotEqual(icon1.rawValue, icon3.rawValue)
+    }
+
+    func testIconEnumFromRawValue() {
+        let original = MaterialDesignIconEnum.favorite48px
+        let recreated = MaterialDesignIconEnum(rawValue: original.rawValue)
+
+        XCTAssertEqual(original, recreated)
+    }
+
+    // MARK: - FontError Tests
+
+    func testFontErrorDescriptions() {
+        let notFoundError = FontError.fontFileNotFound(name: "test-font")
+        XCTAssertTrue(notFoundError.description.contains("test-font"))
+
+        let invalidDataError = FontError.invalidFontData
+        XCTAssertFalse(invalidDataError.description.isEmpty)
+
+        let creationError = FontError.fontCreationFailed
+        XCTAssertFalse(creationError.description.isEmpty)
+
+        let registrationError = FontError.registrationFailed(nil)
+        XCTAssertFalse(registrationError.description.isEmpty)
+    }
+
+    // MARK: - Integration Tests
+
+    func testCreateMultipleSymbolsWithSameIcon() {
+        let icon = MaterialDesignIconEnum.check48px
+
+        let symbol1 = MaterialDesignSymbol(icon: icon, size: 24)
+        let symbol2 = MaterialDesignSymbol(icon: icon, size: 48)
+
+        let image1 = symbol1.image()
+        let image2 = symbol2.image()
+
+        XCTAssertEqual(image1.size.width, 24)
+        XCTAssertEqual(image2.size.width, 48)
+    }
+
+    func testSymbolWithDifferentColors() {
+        let colors: [UIColor] = [.red, .green, .blue, .black, .white]
+
+        for color in colors {
+            let symbol = MaterialDesignSymbol(icon: .close48px, size: 24)
+            symbol.addAttribute(foregroundColor: color)
+            let image = symbol.image()
+
+            XCTAssertNotNil(image)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
- Update Swift Tools version to 5.10 and minimum iOS to 14.0
- Add test target to Package.swift with StrictConcurrency enabled
- Modernize MaterialDesignSymbol with UIGraphicsImageRenderer
- Add Sendable conformance to MaterialDesignFont, FontLoader, and enums
- Improve error handling with descriptive FontError cases
- Replace #if !os(macOS) with #if canImport(UIKit) for consistency
- Add comprehensive unit tests for symbol, font, and icon enum
- Update documentation comments to use modern Swift doc style